### PR TITLE
Make status labels distinct from status values

### DIFF
--- a/rootfs/usr/share/www/index.html
+++ b/rootfs/usr/share/www/index.html
@@ -21,7 +21,7 @@
           {{if .SupervisorConnected}}
           <tr>
             <td>
-              Supported:
+              Support:
             </td>
             <td class="{{if .Supported}}connected{{else if .SupervisorResponse}}disconnected{{end}}">
               {{if .Supported}}Supported{{else if not .SupervisorResponse}}Processing...{{else}}Unsupported
@@ -33,7 +33,7 @@
           </tr>
           <tr>
             <td>
-              Healthy:
+              Health:
             </td>
             <td class="{{if .Healthy}}connected{{else if .SupervisorResponse}}disconnected{{end}}">
               {{if .Healthy}}Healthy{{else if not .SupervisorResponse}}Processing...{{else}}Unhealthy


### PR DESCRIPTION
This is a pretty simple patch that arguably just works around limitations in other tools, but having distinct labels and values allows direct keyword search through the response to integrate into third-party status pages like Kumo (my motivation for this patch).

Ideally the observer would expose a more machine-readable format too, perhaps json when the header `Accepts: application/json` is set, but this should still be useful either way and even in that json payload a distinct key makes sense.