### PR TITLE
Bump Go builder and cosign base verification to Alpine 3.24

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -74,7 +74,7 @@ jobs:
           arch: ${{ matrix.arch }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           cosign-base-identity: 'https://github.com/home-assistant/docker-base/.*'
-          cosign-base-verify: ghcr.io/home-assistant/base:3.23
+          cosign-base-verify: ghcr.io/home-assistant/base:3.24
           image: ${{ matrix.image }}
           image-tags: |
             ${{ needs.init.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=scratch
 
-FROM golang:1.25-alpine3.23 AS builder
+FROM golang:1.25-alpine3.24 AS builder
 
 WORKDIR /workspace/observer-plugin
 ARG TARGETARCH


### PR DESCRIPTION
The observer image itself is built `FROM scratch`, so there is no
home-assistant/base image to bump here. This moves the Go builder stage to
Alpine 3.24 and points the cosign base verification at the 3.24 tag, in line
with the base bumps in the other plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)